### PR TITLE
Add async testing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,13 @@
     "purescript-prelude": "^3.0.0",
     "purescript-console": "^3.0.0",
     "purescript-integers": "^3.0.0",
-    "purescript-st": "^3.0.0",
-    "purescript-partial": "^1.2.0"
+    "purescript-partial": "^1.2.0",
+    "purescript-aff": "^4.0.0",
+    "purescript-arrays": "^4.2.1",
+    "purescript-foldable-traversable": "^3.6.1"
+  },
+  "devDependencies": {
+    "purescript-node-fs": "^4.0.0",
+    "purescript-node-fs-aff": "^5.0.0"
   }
 }

--- a/src/Performance/Minibench.purs
+++ b/src/Performance/Minibench.purs
@@ -1,18 +1,25 @@
 -- | This module provides the `bench` function, which prints a short summary
--- | of the running times of a synchronous function to the console.
+-- | of the running times of a synchronous function to the console. It also
+-- | provides the `benchAff` function, which prints a short summary of the
+-- | running times of an asynchronous block to the console.
 -- |
 -- | For benchmarking tasks which require finer accuracy, or graphs as output,
 -- | consider using `purescript-benchotron` instead.
 
 module Performance.Minibench
   ( bench
+  , benchAff
+  , benchAffWith
   , benchWith
   ) where
 
-import Control.Monad.Eff (Eff, forE)
-import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Aff (Aff, makeAff, runAff, nonCanceler)
+import Control.Monad.Eff (Eff, runPure)
+import Control.Monad.Eff.Console (CONSOLE, logShow)
 import Control.Monad.Eff.Uncurried (EffFn1, runEffFn1)
-import Control.Monad.ST (modifySTRef, newSTRef, readSTRef, runST)
+import Data.Array ((..), (:), length)
+import Data.Either (Either(..))
+import Data.Foldable (foldr)
 import Data.Int (toNumber)
 import Global (infinity)
 import Math (max, min, sqrt)
@@ -35,6 +42,45 @@ withUnits t
   | t < 1.0e9 = toFixed (t / 1.0e6) <> " ms"
   | otherwise = toFixed (t / 1.0e9) <> " s"
 
+-- | When running `bench` or `benchAff`, this is the number of samples that will
+-- | be used.
+defaultNumSamples :: Int
+defaultNumSamples = 1000
+
+-- | The `Results` type is a `Record` newtype that contains information about
+-- | the timings for the test run.
+newtype Results = Results
+  { mean :: Number
+  , stddev :: Number
+  , min' :: Number
+  , max' :: Number
+  }
+
+instance showResults :: Show Results where
+  show (Results results) =
+    "mean   = " <> withUnits results.mean <> "\n" <>
+    "stddev = " <> withUnits results.stddev <> "\n" <>
+    "min    = " <> withUnits results.min' <> "\n" <>
+    "max    = " <> withUnits results.max'
+
+-- | Given an array of run timings, calculate the results for the test.
+results :: forall eff . Array Number -> Results
+results runs = Results {mean, stddev, min', max'}
+  where
+    sum = foldr (+) 0.0 runs
+    sum2 = foldr (\cur -> (+) (cur * cur)) 0.0 runs
+    n = toNumber $ length runs
+    mean = sum / n
+    stddev = sqrt ((sum2 - n * mean * mean) / (n - 1.0))
+    min' = foldr min infinity runs
+    max' = foldr max 0.0 runs
+
+-- | Run a synchronous function n times, returning the array of runtimes.
+runSync :: forall a. Int -> (Unit -> a) -> Array Number
+runSync n f = flip map (0..n) \_ -> fromHrTime $ runPure do
+  t1 <- runEffFn1 hrTime [0, 0]
+  const (runEffFn1 hrTime t1) (f unit)
+
 -- | Estimate the running time of a function and print a summary to the console,
 -- | specifying the number of samples to take. More samples will give a better
 -- | estimate of both mean and standard deviation, but will increase running time.
@@ -43,32 +89,7 @@ benchWith
    . Int
   -> (Unit -> a)
   -> Eff (console :: CONSOLE | eff) Unit
-benchWith n f = runST do
-  sumRef <- newSTRef 0.0
-  sum2Ref <- newSTRef 0.0
-  minRef <- newSTRef infinity
-  maxRef <- newSTRef 0.0
-  forE 0 n \_ -> do
-    t1 <- runEffFn1 hrTime [0, 0]
-    t2 <- const (runEffFn1 hrTime t1) (f unit)
-    let ns     = fromHrTime t2
-        square = ns * ns
-    _ <- modifySTRef sumRef (_ + ns)
-    _ <- modifySTRef sum2Ref (_ + square)
-    _ <- modifySTRef minRef (_ `min` ns)
-    _ <- modifySTRef maxRef (_ `max` ns)
-    pure unit
-  sum <- readSTRef sumRef
-  sum2 <- readSTRef sum2Ref
-  min' <- readSTRef minRef
-  max' <- readSTRef maxRef
-  let n'     = toNumber n
-      mean   = sum / n'
-      stdDev = sqrt ((sum2 - n' * mean * mean) / (n' - 1.0))
-  log ("mean   = " <> withUnits mean)
-  log ("stddev = " <> withUnits stdDev)
-  log ("min    = " <> withUnits min')
-  log ("max    = " <> withUnits max')
+benchWith n = runSync n >>> results >>> logShow
 
 -- | Estimate the running time of a function and print a summary to the console,
 -- | by running the function 1000 times.
@@ -88,4 +109,58 @@ bench
   :: forall eff a
    . (Unit -> a)
   -> Eff (console :: CONSOLE | eff) Unit
-bench = benchWith 1000
+bench = benchWith defaultNumSamples
+
+-- | Run an async Aff n times in sequence, calling the callback with the array
+-- | of runtimes when all have completed.
+runAsync
+  :: forall e a
+   . Int
+  -> Aff e a
+  -> (Array Number -> Eff e Unit)
+  -> Eff e Unit
+runAsync n aff done = runAsync' n []
+  where
+    runAsync' 0 runs = done runs
+    runAsync' n runs = do
+      t1 <- runEffFn1 hrTime [0, 0]
+      void $ flip runAff aff \_ -> do
+        t2 <- runEffFn1 hrTime t1
+        runAsync' (n - 1) ((fromHrTime t2):runs)
+
+-- | Estimate the running time of an Aff and print a summary to the console,
+-- | specifying the number of samples to take. More samples will give a better
+-- | estimate of both mean and standard deviation, but will increase running
+-- | time. Returns an Aff, to make it easy to sequence other asynchronous tests
+-- | without interleaving the results.
+benchAffWith
+  :: forall e a
+   . Int
+  -> Aff (console :: CONSOLE | e) a
+  -> Aff (console :: CONSOLE | e) Unit
+benchAffWith n aff = makeAff \success -> do
+  runAsync n aff \runs -> do
+    logShow $ results runs
+    success $ Right unit
+  pure nonCanceler
+
+-- | Estimate the running time of an Aff monad and print a summary to the
+-- | console, by running the Aff 1000 times. Returns an Aff, to make it easy to
+-- | sequence other asynchronous tests without interleaving the results.
+-- |
+-- | For example:
+-- |
+-- | ```
+-- | > import Data.Array
+-- | > import Data.Foldable
+-- | > import Performance.Minibench
+-- | > void $ launchAff $ benchAff $ readTextFile UTF8 "someFile"
+-- |
+-- | mean   = 414.00 μs
+-- | stddev = 494.82 μs
+-- | ```
+benchAff
+  :: forall e a
+   . Aff (console :: CONSOLE | e) a
+  -> Aff (console :: CONSOLE | e) Unit
+benchAff = benchAffWith defaultNumSamples

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,11 +1,16 @@
 module Test.Main where
 
 import Prelude
+import Control.Monad.Aff (launchAff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
-import Performance.Minibench (bench, benchWith)
+import Control.Monad.Aff.Console as AffConsole
+import Node.Encoding (Encoding(UTF8))
+import Node.FS (FS)
+import Node.FS.Aff (readTextFile)
+import Performance.Minibench (bench, benchAff, benchWith, benchAffWith)
 
-main :: forall e. Eff (console :: CONSOLE | e) Unit
+main :: forall e. Eff (console :: CONSOLE, fs :: FS | e) Unit
 main = do
   let loop 0 = 0
       loop n = loop (n - 1)
@@ -22,3 +27,14 @@ main = do
   bench \_ -> loop 100000
   log "loop 1000000"
   benchWith 100 \_ -> loop 1000000
+
+  void $ launchAff do
+    AffConsole.log "bench aff"
+    benchAff $ readTextFile UTF8 "./test/mockFile"
+    AffConsole.log "bench aff triple read"
+    benchAff do
+      _ <- readTextFile UTF8 "./test/mockFile"
+      _ <- readTextFile UTF8 "./test/mockFile"
+      readTextFile UTF8 "./test/mockFile"
+    AffConsole.log "bench aff x10"
+    benchAffWith 10 $ readTextFile UTF8 "./test/mockFile"

--- a/test/mockFile
+++ b/test/mockFile
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
This PR adds the ability to benchmark `Aff` blocks.  In order to deliver on this, I needed to refactor the internals of the library a bit.  The important change to the existing code is that instead of using the `ST` monad to keep a running state, I made each run return a runtime.  The array of all runtimes is passed in to a function `results` to calculate a `Results` record, which has a `Show` implementation that defines how it is printed on the console.  Let me know thoughts or if you'd like anything modified.