### PR TITLE
Update FFI to be more portable and direct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Update FFI to use a more direct and portable convention (#25 by @natefaubion)
 
 ## [v4.0.0](https://github.com/purescript/purescript-minibench/releases/tag/v4.0.0) - 2022-04-27
 

--- a/src/Performance/Minibench.js
+++ b/src/Performance/Minibench.js
@@ -1,4 +1,9 @@
-export const hrTime = process.hrtime;
+export function timeNs(k) {
+  const t1 = process.hrtime();
+  k();
+  const t2 = process.hrtime(t1);
+  return t2[0] * 1.0e9 + t2[1];
+}
 
 export function gc() {
   global.gc && global.gc();


### PR DESCRIPTION
**Description of the change**

This updates the timing FFI to not bind to `hrtime` directly, which is an odd API in general, instead taking the closure directly and returning the expected nanoseconds.

My primary motivation for doing this is that the existing framework does not work well with `purescript-backend-optimizer`, which aggressively eliminates unused code. The current pattern after inlining results in an unused call to `f`, which means nothing ever gets executed. By using an opaque FFI call, the demand on the closure is kept, and everything works as expected. Normally I wouldn't suggest doing this arbitrarily for this tool, but I think this is a better binding anyway, and is likely easier for other backends to implement since it doesn't rely on the specifics of a Node API.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
